### PR TITLE
Workflowが成功するように変更

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -18,17 +18,17 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-      
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: |
             ghcr.io/${{ github.repository }}
@@ -42,7 +42,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push Docker images
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN apt update && apt install -y sudo git
 
 ARG USERNAME=dockeruser
 ARG GROUPNAME=dockergroup
-ARG UID=1000
-ARG GID=1000
+ARG UID=1001
+ARG GID=1001
 ARG PASSWORD=password
 RUN groupadd -g $GID $GROUPNAME && \
     useradd -m -s /bin/bash -u $UID -g $GID -G sudo $USERNAME && \


### PR DESCRIPTION
- Workflowで使われていた$GIDと$UIDを変更することでbuild時に発生していたエラーを解消しました
- Workflowで使われていたイメージのバージョンをアップデートをしました

## 詳細
Baseイメージとして使用されていたUbuntuイメージにはデフォルトでGIDが1000のUbuntuグループとUIDが1000のUbuntuユーザが存在し、これが追加しようとしていたdockergroup、dockeruserとそれぞれ衝突していました。
このプルリクエストでは、GIDとUIDをそれぞれ1001に変更することでビルドエラーを回避しています。

## 代替案
他の解決手段としてdelgroup、deluserコマンドをそれぞれubuntuグループとubuntuユーザに対して適応する手段もあるので、そちらに変更することも可能です。
